### PR TITLE
Allow any object type for categorical, PowIntPara

### DIFF
--- a/HEBO/bo/design_space/categorical_param.py
+++ b/HEBO/bo/design_space/categorical_param.py
@@ -8,28 +8,24 @@
 # PARTICULAR PURPOSE. See the MIT License for more details.
 
 import numpy as np
-from sklearn.preprocessing import LabelEncoder
 from .param import Parameter
 
 class CategoricalPara(Parameter):
     def __init__(self, param):
         super().__init__(param)
-        self.categories = list(map(str, param['categories']))
-        self.encoder    = LabelEncoder().fit(self.categories)
-        self.lb         = min(self.encoder.transform(self.categories))
-        self.ub         = max(self.encoder.transform(self.categories))
-        assert self.lb == 0
-        assert self.ub == len(self.categories) - 1
+        self.categories = np.array(list(param['categories']))
+        self.lb         = 0
+        self.ub         = len(self.categories) - 1
 
     def sample(self, num = 1):
         assert(num > 0)
-        return self.encoder.inverse_transform(np.random.randint(self.lb, self.ub + 1, num))
+        return np.random.choice(self.categories, num, replace = True)
 
     def transform(self, x : np.ndarray):
-        return self.encoder.transform(x.astype(str).reshape(-1))
+        return x.astype(float)
 
     def inverse_transform(self, x):
-        return self.encoder.inverse_transform(x.round().astype(int).reshape(-1))
+        return self.categories[x.round().astype(int)]
 
     @property
     def is_numeric(self):

--- a/HEBO/bo/design_space/design_space.py
+++ b/HEBO/bo/design_space/design_space.py
@@ -16,12 +16,14 @@ from .integer_param     import IntegerPara
 from .pow_param         import PowPara
 from .categorical_param import CategoricalPara
 from .bool_param        import BoolPara
+from .pow_integer_param         import PowIntegerPara
 
 class DesignSpace:
     def __init__(self):
         self.para_types = {}
         self.register_para_type('num', NumericPara)
         self.register_para_type('pow', PowPara)
+        self.register_para_type('pow_int', PowIntegerPara)
         self.register_para_type('int', IntegerPara)
         self.register_para_type('cat', CategoricalPara)
         self.register_para_type('bool', BoolPara)

--- a/HEBO/bo/design_space/pow_integer_param.py
+++ b/HEBO/bo/design_space/pow_integer_param.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020. Huawei Technologies Co., Ltd. All rights reserved.
+
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the MIT license.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the MIT License for more details.
+
+import sys
+import numpy as np
+from .param import Parameter
+
+class PowIntegerPara(Parameter):
+    def __init__(self, param_dict):
+        super().__init__(param_dict)
+        self.base = param_dict.get('base', 10.)
+        self.lb   = np.log(param_dict['lb']) / np.log(self.base)
+        self.ub   = np.log(param_dict['ub']) / np.log(self.base)
+
+    def sample(self, num = 1):
+        assert(num > 0)
+        return (self.base ** np.random.uniform(self.lb, self.ub, num)).round().astype(int)
+
+    def transform(self, x):
+        return np.log(x) / np.log(self.base)
+
+    def inverse_transform(self, x):
+        return (self.base ** x).round().astype(int)
+
+    @property
+    def is_numeric(self):
+        return True
+
+    @property
+    def opt_lb(self):
+        return self.lb
+
+    @property
+    def opt_ub(self):
+        return self.ub
+
+    @property
+    def is_discrete(self):
+        return True


### PR DESCRIPTION
This PR allows for any object type to be used in `CategoricalPara` instead of just strings (eg. tuples for layer sizes in sklearn's MLPClassifier, various collections). Two approaches are included - a faster, dict based one if all objects are hashable and a slower, array based one to fall back on. There should not be a noticeable performance difference compared to the old string-only approach in either case.

In addition, `PowIntegetrPara` is added, being a log-uniform integer parameter to compliment `PowPara`.