### PR TITLE
[BO-HEBO] validate_args=False for Normal distribution

### DIFF
--- a/BO/HEBO/hebo/acquisitions/acq.py
+++ b/BO/HEBO/hebo/acquisitions/acq.py
@@ -153,7 +153,7 @@ class MACE(Acquisition):
             ps        = ps2.sqrt()
             lcb       = (py + noise * torch.randn(py.shape)) - self.kappa * ps
             normed    = ((self.tau - self.eps - py - noise * torch.randn(py.shape)) / ps)
-            dist      = Normal(0., 1.)
+            dist      = Normal(0., 1. validate_args=False)
             log_phi   = dist.log_prob(normed)
             Phi       = dist.cdf(normed)
             PI        = Phi

--- a/BO/HEBO/hebo/acquisitions/acq.py
+++ b/BO/HEBO/hebo/acquisitions/acq.py
@@ -153,7 +153,7 @@ class MACE(Acquisition):
             ps        = ps2.sqrt()
             lcb       = (py + noise * torch.randn(py.shape)) - self.kappa * ps
             normed    = ((self.tau - self.eps - py - noise * torch.randn(py.shape)) / ps)
-            dist      = Normal(0., 1. validate_args=False)
+            dist      = Normal(0., 1., validate_args=False)
             log_phi   = dist.log_prob(normed)
             Phi       = dist.cdf(normed)
             PI        = Phi


### PR DESCRIPTION
In Torch 1.8, a change was made where `validate_args` for distributions is set to True. This sometimes causes an exception. Setting `validate_args=False` returns to previous behavior by ignoring any exceptions in MACE acquisition function.