### PR TITLE
fix the bug in function observe_count

### DIFF
--- a/o2despy/o2despy/hour_counter.py
+++ b/o2despy/o2despy/hour_counter.py
@@ -291,7 +291,7 @@ class HourCounter(IHourCounter):
                     if self.__paused:
                         f.write(', Paused')
                     f.writelines('')
-        self.__last_count = clock_time
+        self.__last_time = clock_time
         self.__last_count = count
         if self.__keep_history:
             self.__history[clock_time] = count


### PR DESCRIPTION
In o2despy/o2despy/hour_counter.py, line #294.
There should be assign clock_time to __last_time, instead of __last_count.
I believe that should be a typo, which causes logic error.
Thank you.